### PR TITLE
Indentation for arguments spanning multiple lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ Translations of the guide are available in the following languages:
 
 * <a name="body-indentation"></a>
 Use 2 spaces to indent the bodies of forms that have body parameters
-that span multiple lines. This covers all `def` forms, special forms
-and macros that introduce local bindings (e.g. `loop`, `let`, `when-let`)
-and many macros like `when`, `with-*`, `case`, `cond`, etc.
+that span multiple lines. This covers all `def` forms, special
+forms and macros that introduce local bindings (e.g. `loop`, `let`,
+`when-let`) and many macros like `when`, `cond`, `as->`, `cond->`, `case`,
+`with-*`, etc.
 <sup>[[link](#body-indentation)]</sup>
 
 

--- a/README.md
+++ b/README.md
@@ -122,30 +122,35 @@ forms and macros that introduce local bindings (e.g. `loop`, `let`,
     ;; good
     (do-this this-arg this-other-arg)
     
-    ;; good
     (do-this
       this-arg this-other-arg)
     
-    ;; good
     (do-this
       this-arg
       this-other-arg)
+    
+    (if condition
+      then
+      else)
+    
+    (if condition
+        then
+        else)
+        
+    (or 
+      this
+      that
+      other)
+    
+    (or this
+        that
+        other)
 
     ;; good only if line length doesn't permit `this-other-arg` on the same line
     (do-this this-arg
       this-other-arg)
-      
-    ;; good
-    (if condition
-      then
-      else)
-      
-    ;; also good
-    (if condition
-        then
-        else)
 
-    ;; okay
+    ;; only 'okay', because function name is a little long to align args with it 
     (my-function this-arg
                  this-other-arg)
         

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ on its own line and separating the pairs with a newline.
     (do-this
       this-arg
       this-other-arg)
+      
+    (do-this this-arg
+             this-other-arg)
     
     (if condition
         then
@@ -170,7 +173,7 @@ on its own line and separating the pairs with a newline.
     (do-this this-arg
       this-other-arg)
 
-    ;; okay
+    ;; okay (either function/macro name too long to align args, or too short to indent args)
     (my-function this-arg
                  this-other-arg)
                  

--- a/README.md
+++ b/README.md
@@ -71,18 +71,25 @@ Translations of the guide are available in the following languages:
 <sup>[[link](#spaces)]</sup>
 
 * <a name="body-indentation"></a>
-Use 2 spaces to indent the bodies of
-forms that have body parameters.  This covers all `def` forms, special
-forms and macros that introduce local bindings (e.g. `loop`, `let`,
-`when-let`) and many macros like `when`, `cond`, `as->`, `cond->`, `case`,
-`with-*`, etc.
+Use 2 spaces to indent the bodies of forms that have body parameters
+that span multiple lines. This covers all `def` forms, special forms
+and macros that introduce local bindings (e.g. `loop`, `let`, `when-let`)
+and many macros like `when`, `with-*`, `case`, `cond`, etc.
 <sup>[[link](#body-indentation)]</sup>
 
 
     ```Clojure
     ;; good
+    (when something (something-else))
+    
     (when something
       (something-else))
+      
+    (cond this that :else other)
+    
+    (cond
+      this that
+      :else other)
 
     (with-out-str
       (println "Hello, ")
@@ -98,28 +105,58 @@ forms and macros that introduce local bindings (e.g. `loop`, `let`,
      (println "world!"))
     ```
 
-* <a name="align-fn-args"></a>
-  Use 2 spaces to indent function (macro) arguments spanning multiple lines.
-<sup>[[link](#align-fn-args)]</sup>
+* <a name="align-args"></a>
+  Use 2 spaces (or else align the arguments, especially if the
+  function/macro name is short) to indent function (macro) arguments
+  spanning multiple lines.
+
+  Arguments that span multiple lines should either take up as much of
+  the line as possible, or they should take up one line each after the
+  function/macro name. The only exception to this rule is `if`, in
+  which case the conditional argument can be on the same line as the
+  `if` macro name.
+<sup>[[link](#align-args)]</sup>
 
     ```Clojure
     ;; good
-    (my-function
+    (do-this this-arg this-other-arg)
+    
+    ;; good
+    (do-this
       this-arg this-other-arg)
+    
+    ;; good
+    (do-this
+      this-arg
+      this-other-arg)
 
     ;; good only if line length doesn't permit `this-other-arg` on the same line
-    (my-function this-arg
+    (do-this this-arg
       this-other-arg)
+      
+    ;; good
+    (if condition
+      then
+      else)
+      
+    ;; also good
+    (if condition
+        then
+        else)
 
     ;; okay
     (my-function this-arg
                  this-other-arg)
-
+        
     ;; bad
     (my-function this-arg
             this-other-arg)
-
-
+        
+    ;; bad if the line breaks below happen despite args not filling max space on a line
+    (my-function this-arg
+      this-other-arg yet-another-arg
+      and-another-arg
+      one-other-arg and-maybe-another)
     ```
 
 * <a name="vertically-align-let-and-map"></a>

--- a/README.md
+++ b/README.md
@@ -159,17 +159,8 @@ on its own line and separating the pairs with a newline.
       this-other-arg)
     
     (if condition
-      then
-      else)
-    
-    (if condition
         then
         else)
-        
-    (or 
-      this
-      that
-      other)
     
     (or this
         that
@@ -179,9 +170,18 @@ on its own line and separating the pairs with a newline.
     (do-this this-arg
       this-other-arg)
 
-    ;; only 'okay', because function name is a little long to align args with it 
+    ;; okay
     (my-function this-arg
                  this-other-arg)
+                 
+    (if condition
+      then
+      else)
+      
+    (or 
+      this
+      that
+      other)
         
     ;; bad
     (my-function this-arg

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ that span multiple lines. This covers all `def` forms, special
 forms and macros that introduce local bindings (e.g. `loop`, `let`,
 `when-let`) and many macros like `when`, `cond`, `as->`, `cond->`, `case`,
 `with-*`, etc.
+For macros that take pairs of arguments (e.g. `cond`, `cond->`, `case`),
+it is acceptable to group the pairs by either putting each pair on the same
+line or (especially when pairs are long) by putting each member of each pair
+on its own line and separating the pairs with a newline.
 <sup>[[link](#body-indentation)]</sup>
 
 
@@ -91,10 +95,35 @@ forms and macros that introduce local bindings (e.g. `loop`, `let`,
     (cond
       this that
       :else other)
+      
+    (cond
+      this 
+      that
+      
+      :else 
+      other)
 
     (with-out-str
       (println "Hello, ")
       (println "world!"))
+
+    ;; bad
+    (cond
+      this that
+      
+      :else 
+      other)
+      
+    (cond
+      this 
+      that
+      :else 
+      other)
+      
+    (cond
+      this that
+      :else 
+      other)
 
     ;; bad - four spaces
     (when something

--- a/README.md
+++ b/README.md
@@ -98,45 +98,28 @@ forms and macros that introduce local bindings (e.g. `loop`, `let`,
      (println "world!"))
     ```
 
-* <a name="vertically-align-fn-args"></a>
-  Vertically align function (macro) arguments spanning multiple lines.
-<sup>[[link](#vertically-align-fn-args)]</sup>
+* <a name="align-fn-args"></a>
+  Use 2 spaces to indent function (macro) arguments spanning multiple lines.
+<sup>[[link](#align-fn-args)]</sup>
 
     ```Clojure
     ;; good
-    (filter even?
-            (range 1 10))
+    (my-function
+      this-arg this-other-arg)
+
+    ;; good only if line length doesn't permit `this-other-arg` on the same line
+    (my-function this-arg
+      this-other-arg)
+
+    ;; okay
+    (my-function this-arg
+                 this-other-arg)
 
     ;; bad
-    (filter even?
-      (range 1 10))
-    ```
+    (my-function this-arg
+            this-other-arg)
 
-* <a name="one-space-indent"></a>
-Use a single space indentation for function (macro) arguments
-when there are no arguments on the same line as the function name.
-<sup>[[link](#one-space-indent)]</sup>
 
-    ```Clojure
-    ;; good
-    (filter
-     even?
-     (range 1 10))
-
-    (or
-     ala
-     bala
-     portokala)
-
-    ;; bad - two-space indent
-    (filter
-      even?
-      (range 1 10))
-
-    (or
-      ala
-      bala
-      portokala)
     ```
 
 * <a name="vertically-align-let-and-map"></a>


### PR DESCRIPTION
I think it would be really great if, for function/macro arguments, we could discourage 1-space indentation and encourage the option of either 2-space indentation or alignment with the function/macro name,  as shown in the diff for this PR. As https://github.com/bbatsov/clojure-style-guide/issues/126 points out, both The Joy of Clojure (the definitive Clojure book) and the popular [ring](https://github.com/ring-clojure/ring/blob/master/ring-core/src/ring/middleware/nested_params.clj#L50-L54) repository use this style. I echo the opinion voiced in the linked issue when I say that at the very least I think the style guide should be agnostic with respect to 1- vs. 2-space indents.